### PR TITLE
F/collect payment token

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -340,4 +340,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->endpoint;
     }
+
+    public function getPaymentToken()
+    {
+        return $this->getParameter('payment_token');
+    }
+
+    public function setPaymentToken($value)
+    {
+        return $this->setParameter('payment_token', $value);
+    }
 }

--- a/src/Message/DirectPostCreateCardRequest.php
+++ b/src/Message/DirectPostCreateCardRequest.php
@@ -11,13 +11,16 @@ class DirectPostCreateCardRequest extends AbstractRequest
 
     public function getData()
     {
-        $this->validate('card');
-        $this->getCard()->validate();
-
+		$this->validate('card');
         $data = $this->getBaseData();
 
-        $data['ccnumber'] = $this->getCard()->getNumber();
-        $data['ccexp'] = $this->getCard()->getExpiryDate('my');
+		if ($paymentToken = $this->getPaymentToken()) {
+			$data['payment_token'] = $paymentToken;
+		} else {
+			$this->getCard()->validate();
+			$data['ccnumber'] = $this->getCard()->getNumber();
+			$data['ccexp'] = $this->getCard()->getExpiryDate('my');
+		}
         $data['payment'] = 'creditcard';
 
         if ('update_customer' === $this->customer_vault) {


### PR DESCRIPTION
Adds support for using a Direct Post API `payment_token` created via [Collect.js](https://github.com/loadsys/omnipay-nmi/pull/new/f/collect-payment-token) in place of credit card number and expiration date.

Example usage:

```php
$gateway = Omnipay::create('NMI_DirectPost');
$response = $gateway
  ->createCard(['card' => $data['billing_data'])
  ->setPaymentToken($data['payment_token'])
  ->send();
```